### PR TITLE
chore(webapps): bump requirejs to latest - 2.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "grunt travis --verbose"
   },
   "dependencies": {
-    "requirejs": "2.1.x"
+    "requirejs": "2.3.7"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
related to: https://github.com/camunda/camunda-bpm-platform/issues/4489